### PR TITLE
fix Poisson blurred face mask for other webcam video sizes

### DIFF
--- a/examples/facesubstitution.html
+++ b/examples/facesubstitution.html
@@ -395,7 +395,7 @@
 				}
 					
 				function switchMasks(pos) {
-					videocanvas.getContext('2d').drawImage(vid,0,0);
+					videocanvas.getContext('2d').drawImage(vid,0,0,videocanvas.width,videocanvas.height);
 					
 					// we need to extend the positions with new estimated points in order to get pixels immediately outside mask
 					var newMaskPos = masks[images[currentMask]].slice(0);


### PR DESCRIPTION
Unless the video from the webcam is exactly 600x450, the overlaid face
mask does not match the video image. (This leads to weirdness like
http://goo.gl/pWVFWF.) The fix is simple: make sure to resize the video
image before overlaying the mask image.
