### PR TITLE
send an event just before the tracking proceeds

### DIFF
--- a/clmtrackr.js
+++ b/clmtrackr.js
@@ -309,6 +309,10 @@ var clm = {
 		 */
 		this.track = function(element, box) {
 			
+			var evt = document.createEvent("Event");
+			evt.initEvent("clmtrackrBeforeTrack", true, true);
+			document.dispatchEvent(evt)
+			
 			var scaling, translateX, translateY, rotation;
 			var croppedPatches = [];
 			var ptch, px, py;


### PR DESCRIPTION
i found this especially useful when working with a modified canvas data rather than raw video output, i would copy and process video output in a specific way just before the tracking would occur
