### PR TITLE
Fix issue with handling multiple camera aspect ratios

### DIFF
--- a/examples/caricature.html
+++ b/examples/caricature.html
@@ -23,8 +23,7 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
+				
 			}
 
 			#videoel {
@@ -34,8 +33,7 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
+				
 			}
 
 			#container {

--- a/examples/clm_emotiondetection.html
+++ b/examples/clm_emotiondetection.html
@@ -24,8 +24,7 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
+				
 			}
 
 			#videoel {
@@ -35,8 +34,7 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
+				
 			}
 
 			#container {

--- a/examples/clm_genderdetection.html
+++ b/examples/clm_genderdetection.html
@@ -24,8 +24,6 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
 			}
 
 			#videoel {
@@ -35,8 +33,6 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
 			}
 
 			#container {

--- a/examples/facedeform.html
+++ b/examples/facedeform.html
@@ -23,8 +23,7 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
+				
 			}
 
 			#videoel {
@@ -34,8 +33,7 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
+			
 			}
 
 			#container {

--- a/examples/facesubstitution.html
+++ b/examples/facesubstitution.html
@@ -23,8 +23,6 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
 			}
 
 			#videoel {
@@ -34,8 +32,6 @@
 				-ms-filter : fliph; /*IE*/
 				filter : fliph; /*IE*/
 
-				width : 600px;
-				height : 450px;
 			}
 
 			#container {


### PR DESCRIPTION
The CSS width and height were taking priority over the `vid.width` and `vid.height` properties, so I removed them. I have tested this on my laptop, and a Moto Z Play with 3:4 camera aspect ratio in portrait and 4:3 in landscape.