### PR TITLE
Improve track performance in Chrome

### DIFF
--- a/build/clmtrackr.module.js
+++ b/build/clmtrackr.module.js
@@ -4524,7 +4524,7 @@ if(!raf || !caf) {
   };
 }
 
-var index = function(fn) {
+var raf_1 = function(fn) {
   // Wrap in a new function to prevent
   // `cancel` potentially being assigned
   // to the native rAF function
@@ -4533,13 +4533,16 @@ var index = function(fn) {
 var cancel = function() {
   caf.apply(root, arguments);
 };
-var polyfill = function() {
-  root.requestAnimationFrame = raf;
-  root.cancelAnimationFrame = caf;
+var polyfill = function(object) {
+  if (!object) {
+    object = root;
+  }
+  object.requestAnimationFrame = raf;
+  object.cancelAnimationFrame = caf;
 };
 
-index.cancel = cancel;
-index.polyfill = polyfill;
+raf_1.cancel = cancel;
+raf_1.polyfill = polyfill;
 
 var promise = createCommonjsModule(function (module) {
 (function (root) {
@@ -4558,7 +4561,7 @@ var promise = createCommonjsModule(function (module) {
   }
 
   function Promise(fn) {
-    if (typeof this !== 'object') throw new TypeError('Promises must be constructed via new');
+    if (!(this instanceof Promise)) throw new TypeError('Promises must be constructed via new');
     if (typeof fn !== 'function') throw new TypeError('not a function');
     this._state = 0;
     this._handled = false;
@@ -4682,9 +4685,9 @@ var promise = createCommonjsModule(function (module) {
   };
 
   Promise.all = function (arr) {
-    var args = Array.prototype.slice.call(arr);
-
     return new Promise(function (resolve, reject) {
+      if (!arr || typeof arr.length === 'undefined') throw new TypeError('Promise.all accepts an array');
+      var args = Array.prototype.slice.call(arr);
       if (args.length === 0) return resolve([]);
       var remaining = args.length;
 
@@ -14303,7 +14306,7 @@ var version = "1.1.2";
 var DEFAULT_MODEL = model_pca_20_svm;
 
 // polyfills
-index.polyfill();
+raf_1.polyfill();
 if (!window.Promise) window.Promise = promise;
 
 var clm = {
@@ -14359,6 +14362,8 @@ var clm = {
 		var detectingFace = false;
 
 		var convergenceLimit = 0.01;
+
+		var isChrome = navigator.userAgent.indexOf("Chrome") > -1;
 
 		var searchWindow;
 		var modelWidth, modelHeight;
@@ -14690,20 +14695,37 @@ var clm = {
 			}
 
 
-			var pdata, pmatrix, grayscaleColor;
-			for (var i = 0; i < numPatches; i++) {
-				px = patchPositions[i][0]-(pw/2);
-				py = patchPositions[i][1]-(pl/2);
-				ptch = sketchCC.getImageData(Math.round(px), Math.round(py), pw, pl);
-				pdata = ptch.data;
+            var i, j, pmatrix, grayscaleColor, lineNum, inx, offset, sketchData, sketchpData, pdata;
+            if (isChrome) {
+                sketchData = sketchCC.getImageData(0, 0, sketchCanvas.width, sketchCanvas.height);
+                sketchpData = sketchData.data;
+                for (i = 0; i < numPatches; i++) {
+                    px = Math.round(patchPositions[i][0] - (pw / 2));
+                    py = Math.round(patchPositions[i][1] - (pl / 2));
+                    pmatrix = patches[i];
+                    for (j = 0; j < pdataLength; j++) {
+                        lineNum = parseInt((j + 1) / pw);
+                        inx = j % pw;
+                        offset = (py + lineNum) * sketchCanvas.width * 4 + (px + inx) * 4;
+                        grayscaleColor = sketchpData[offset] * 0.3 + sketchpData[1 + offset] * 0.59 + sketchpData[2 + offset] * 0.11;
+                        pmatrix[j] = grayscaleColor;
+                    }
+                }
+            } else {
+                for (i = 0; i < numPatches; i++) {
+                    px = patchPositions[i][0] - (pw / 2);
+                    py = patchPositions[i][1] - (pl / 2);
+                    ptch = sketchCC.getImageData(Math.round(px), Math.round(py), pw, pl);
+                    pdata = ptch.data;
 
-				// convert to grayscale
-				pmatrix = patches[i];
-				for (var j = 0;j < pdataLength;j++) {
-					grayscaleColor = pdata[j*4]*0.3 + pdata[(j*4)+1]*0.59 + pdata[(j*4)+2]*0.11;
-					pmatrix[j] = grayscaleColor;
-				}
-			}
+                    // convert to grayscale
+                    pmatrix = patches[i];
+                    for (j = 0; j < pdataLength; j++) {
+                        grayscaleColor = pdata[j * 4] * 0.3 + pdata[(j * 4) + 1] * 0.59 + pdata[(j * 4) + 2] * 0.11;
+                        pmatrix[j] = grayscaleColor;
+                    }
+                }
+            }
 
 			// draw weights for debugging
 			//drawPatches(sketchCC, weights, patchSize, patchPositions, function(x) {return x*2000+127});

--- a/src/clm.js
+++ b/src/clm.js
@@ -86,6 +86,8 @@ var clm = {
 
 		var convergenceLimit = 0.01;
 
+		var isChrome = navigator.userAgent.indexOf("Chrome") > -1
+
 		var searchWindow;
 		var modelWidth, modelHeight;
 		var halfSearchWindow, vecProbs, responsePixels;
@@ -416,20 +418,37 @@ var clm = {
 			}
 
 
-			var pdata, pmatrix, grayscaleColor;
-			for (var i = 0; i < numPatches; i++) {
-				px = patchPositions[i][0]-(pw/2);
-				py = patchPositions[i][1]-(pl/2);
-				ptch = sketchCC.getImageData(Math.round(px), Math.round(py), pw, pl);
-				pdata = ptch.data;
+            var i, j, pmatrix, grayscaleColor, lineNum, inx, offset, sketchData, sketchpData, pdata;
+            if (isChrome) {
+                sketchData = sketchCC.getImageData(0, 0, sketchCanvas.width, sketchCanvas.height);
+                sketchpData = sketchData.data;
+                for (i = 0; i < numPatches; i++) {
+                    px = Math.round(patchPositions[i][0] - (pw / 2));
+                    py = Math.round(patchPositions[i][1] - (pl / 2));
+                    pmatrix = patches[i];
+                    for (j = 0; j < pdataLength; j++) {
+                        lineNum = parseInt((j + 1) / pw);
+                        inx = j % pw;
+                        offset = (py + lineNum) * sketchCanvas.width * 4 + (px + inx) * 4;
+                        grayscaleColor = sketchpData[offset] * 0.3 + sketchpData[1 + offset] * 0.59 + sketchpData[2 + offset] * 0.11;
+                        pmatrix[j] = grayscaleColor;
+                    }
+                }
+            } else {
+                for (i = 0; i < numPatches; i++) {
+                    px = patchPositions[i][0] - (pw / 2);
+                    py = patchPositions[i][1] - (pl / 2);
+                    ptch = sketchCC.getImageData(Math.round(px), Math.round(py), pw, pl);
+                    pdata = ptch.data;
 
-				// convert to grayscale
-				pmatrix = patches[i];
-				for (var j = 0;j < pdataLength;j++) {
-					grayscaleColor = pdata[j*4]*0.3 + pdata[(j*4)+1]*0.59 + pdata[(j*4)+2]*0.11;
-					pmatrix[j] = grayscaleColor;
-				}
-			}
+                    // convert to grayscale
+                    pmatrix = patches[i];
+                    for (j = 0; j < pdataLength; j++) {
+                        grayscaleColor = pdata[j * 4] * 0.3 + pdata[(j * 4) + 1] * 0.59 + pdata[(j * 4) + 2] * 0.11;
+                        pmatrix[j] = grayscaleColor;
+                    }
+                }
+            }
 
 			// draw weights for debugging
 			//drawPatches(sketchCC, weights, patchSize, patchPositions, function(x) {return x*2000+127});


### PR DESCRIPTION
When track running in chrome(v63.0.3239.132), this loop in `src/clm.js` can cost more then 50ms. 
(Safari & FireFox have no problem, only cost 1-3ms)

```
for (i = 0; i < numPatches; i++) {
    px = patchPositions[i][0] - (pw / 2);
    py = patchPositions[i][1] - (pl / 2);
    ptch = sketchCC.getImageData(Math.round(px), Math.round(py), pw, pl);
    pdata = ptch.data;

    // convert to grayscale
    pmatrix = patches[i];
    for (j = 0; j < pdataLength; j++) {
        grayscaleColor = pdata[j * 4] * 0.3 + pdata[(j * 4) + 1] * 0.59 + pdata[(j * 4) + 2] * 0.11;
        pmatrix[j] = grayscaleColor;
    }
}
```

and most time costed by this line `ptch = sketchCC.getImageData(Math.round(px), Math.round(py), pw, pl);`

It seems calling `getImageData()` is  very expensive in chrome, put `sketchCC.getImageData()` out of the loop can greatly improve the performance.

```
sketchData = sketchCC.getImageData(0, 0, sketchCanvas.width, sketchCanvas.height);
sketchpData = sketchData.data;
for (i = 0; i < numPatches; i++) {
    px = Math.round(patchPositions[i][0] - (pw / 2));
    py = Math.round(patchPositions[i][1] - (pl / 2));
    pmatrix = patches[i];
    for (j = 0; j < pdataLength; j++) {
        lineNum = parseInt((j + 1) / pw);
        inx = j % pw;
        offset = (py + lineNum) * sketchCanvas.width * 4 + (px + inx) * 4;
        grayscaleColor = sketchpData[offset] * 0.3 + sketchpData[1 + offset] * 0.59 + sketchpData[2 + offset] * 0.11;
        pmatrix[j] = grayscaleColor;
    }
}
```
